### PR TITLE
Support credentials without an `id` property.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-web-wallet ChangeLog
 
+## 8.2.0 - 2022-08-xx
+
+### Added
+- Add support for credentials without an `id` property.
+
 ## 8.1.1 - 2022-06-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 ### Added
 - Add support for credentials without an `id` property.
 
+### Changed
+- Use `@bedrock/web-vc-store@7.4` to get storage features for VCs without
+  `id` property.
+
 ## 8.1.1 - 2022-06-03
 
 ### Fixed

--- a/lib/CredentialStore.js
+++ b/lib/CredentialStore.js
@@ -109,7 +109,7 @@ function _createBundleContents({
       bundleContents.push(entry);
 
       // recursively handle any sub-bundle contents
-      if(credential.id && subFilter.bundleContents) {
+      if(subFilter.bundleContents) {
         const contents = _createBundleContents({
           holder, defaultMeta, filter: subFilter, filterMap, remaining
         });
@@ -170,8 +170,8 @@ function _createUpsertOps({holder, credentials, store}) {
       // always add `holder` to meta
       const op = {credential, meta: {holder, ...meta}};
 
-      // a credential can only be a bundle if it has an ID
-      if(credential.id && filter.bundleContents) {
+      // handle any bundled contents
+      if(filter.bundleContents) {
         const contents = _createBundleContents({
           holder, defaultMeta, filter, filterMap, remaining
         });

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@bedrock/web-profile-manager": "^17.2.0",
     "@bedrock/web-pouch-edv": "^6.0.0",
     "@bedrock/web-session": "^4.0.0",
-    "@bedrock/web-vc-store": "^7.3.0"
+    "@bedrock/web-vc-store": "^7.4.0"
   },
   "engines": {
     "node": ">=14"

--- a/test/package.json
+++ b/test/package.json
@@ -21,7 +21,7 @@
     "@bedrock/web-pouch-edv": "^5.0.0",
     "@bedrock/web-profile-manager": "^17.0.0",
     "@bedrock/web-session": "^4.0.0",
-    "@bedrock/web-vc-store": "^7.0.0",
+    "@bedrock/web-vc-store": "^7.4.0",
     "@bedrock/web-wallet": "file:.."
   }
 }


### PR DESCRIPTION
Depends on an updated version of `@bedrock/web-vc-store` (https://github.com/digitalbazaar/bedrock-web-vc-store/pull/23).