### PR TITLE
Merge the contents of `profileContent` to the `profile` returned from  `createProfile()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## 11.0.1 - 2023-TBD
 
 ### Fixed
-- Add `profileContent` fields `name`, `color` and `shared` to the `profile`
-  returned from `createProfile()` in `lib/helpers.js`.
+- Merge the contents of `profileContent` to the `profile` returned from
+  `createProfile()` in `lib/helpers.js`.
 
 ## 11.0.0 - 2023-01-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # bedrock-web-wallet ChangeLog
 
+## 11.0.1 - 2023-TBD
+
+### Fixed
+- Add `profileContent` fields `name`, `color` and `shared` to the `profile`
+  returned from `createProfile()` in `lib/helpers.js`.
+
 ## 11.0.0 - 2023-01-24
 
 ### Changed

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -121,27 +121,21 @@ export const createProfile = async ({
       {accessManager, profileId, profileContent})
   ]);
 
+  let updatedProfile;
   // if profile content was provided, kick off request to update cache
   if(profileContent) {
     // set `useCache: false` to fetch a fresh copy
     profileManager.getProfile({id: profileId, useCache: false})
       .catch(() => {});
-    const {name, color, shared} = profileContent;
-    if(name) {
-      profile.name = name;
-    }
-    if(color) {
-      profile.color = color;
-    }
-    if(shared) {
-      profile.shared = shared;
-    }
+    updatedProfile = _mergeProfileContent({
+      profile, profileContent
+    });
   }
 
   const t1 = Date.now();
   console.log('profile creation time', t1 - t0, 'ms');
 
-  return {profileAgent: user || profileAgent, profile};
+  return {profileAgent: user || profileAgent, profile: updatedProfile};
 };
 
 export async function openFirstPartyWindow(event) {
@@ -173,11 +167,12 @@ async function _updateProfileAgentUser({
     id: profileAgent.id,
     async mutator({existing}) {
       const updatedDoc = {...existing};
-
+      const mergedContent = _mergeProfileContent({
+        profile: updatedDoc.content, profileContent: profileAgentContent
+      });
       // add profile agent content
       updatedDoc.content = {
-        ...updatedDoc.content,
-        ...profileAgentContent,
+        ...mergedContent,
         // special handle type to include required types
         type: _addTypes({
           existingTypes: ['User', 'Agent'],
@@ -230,4 +225,11 @@ function _addTypes({existingTypes, newTypes}) {
     newTypes.forEach(types.add.bind(types));
   }
   return [...types];
+}
+
+function _mergeProfileContent({profile, profileContent} = {}) {
+  return {
+    ...profileContent,
+    ...profile,
+  };
 }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -121,7 +121,7 @@ export const createProfile = async ({
       {accessManager, profileId, profileContent})
   ]);
 
-  let updatedProfile;
+  let updatedProfile = profile;
   // if profile content was provided, kick off request to update cache
   if(profileContent) {
     // set `useCache: false` to fetch a fresh copy
@@ -168,8 +168,8 @@ async function _updateProfileAgentUser({
     async mutator({existing}) {
       const updatedDoc = {...existing};
       // add profile agent content
-      updatedDoc.content = _mergeProfileContent({
-        profile: updatedDoc.content, profileContent: profileAgentContent
+      updatedDoc.content = _mergeProfileAgentContent({
+        profileAgent: updatedDoc.content, profileAgentContent
       });
       return updatedDoc;
     }
@@ -202,25 +202,33 @@ function _addTypes({existingTypes, newTypes}) {
   return [...types];
 }
 
-function _mergeProfileContent({profile, profileContent} = {}) {
-  let existingTypes;
-  if(profile.type.includes('Agent')) {
-    existingTypes = ['User', 'Agent'];
-  } else if(profile.type.includes('Profile')) {
-    existingTypes = ['User', 'Profile'];
-  }
+function _mergeContent({target, content, existingTypes} = {}) {
   return {
-    ...profileContent,
-    ...profile,
+    ...content,
+    ...target,
     // special handle type to include required types
     type: _addTypes({
       existingTypes,
-      newTypes: profileContent.type
+      newTypes: content.type
     }),
     // special handle zcaps to avoid overwrites
     zcaps: {
-      ...profile.zcaps,
-      ...profileContent.zcaps
+      ...target.zcaps,
+      ...content.zcaps
     }
   };
+}
+
+function _mergeProfileContent({profile, profileContent} = {}) {
+  return _mergeContent({
+    target: profile, content: profileContent,
+    existingTypes: ['User', 'Profile']
+  });
+}
+
+function _mergeProfileAgentContent({profileAgent, profileAgentContent} = {}) {
+  return _mergeContent({
+    target: profileAgent, content: profileAgentContent,
+    existingTypes: ['User', 'Agent']
+  });
 }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -167,23 +167,10 @@ async function _updateProfileAgentUser({
     id: profileAgent.id,
     async mutator({existing}) {
       const updatedDoc = {...existing};
-      const mergedContent = _mergeProfileContent({
+      // add profile agent content
+      updatedDoc.content = _mergeProfileContent({
         profile: updatedDoc.content, profileContent: profileAgentContent
       });
-      // add profile agent content
-      updatedDoc.content = {
-        ...mergedContent,
-        // special handle type to include required types
-        type: _addTypes({
-          existingTypes: ['User', 'Agent'],
-          newTypes: profileAgentContent.type
-        }),
-        // special handle zcaps to avoid overwrites
-        zcaps: {
-          ...updatedDoc.content.zcaps,
-          ...profileAgentContent.zcaps
-        }
-      };
       return updatedDoc;
     }
   });
@@ -196,23 +183,10 @@ async function _updateProfileUser({
     id: profileId,
     async mutator({existing}) {
       const updatedDoc = {...existing};
-      const mergedContent = _mergeProfileContent({
+      // add profile content
+      updatedDoc.content = _mergeProfileContent({
         profile: updatedDoc.content, profileContent
       });
-      // add profile agent content
-      updatedDoc.content = {
-        ...mergedContent,
-        // special handle type to include required types
-        type: _addTypes({
-          existingTypes: ['User', 'Profile'],
-          newTypes: profileContent.type
-        }),
-        // special handle zcaps to avoid overwrites
-        zcaps: {
-          ...updatedDoc.content.zcaps,
-          ...profileContent.zcaps
-        }
-      };
       return updatedDoc;
     }
   });
@@ -229,8 +203,24 @@ function _addTypes({existingTypes, newTypes}) {
 }
 
 function _mergeProfileContent({profile, profileContent} = {}) {
+  let existingTypes;
+  if(profile.type.includes('Agent')) {
+    existingTypes = ['User', 'Agent'];
+  } else if(profile.type.includes('Profile')) {
+    existingTypes = ['User', 'Profile'];
+  }
   return {
     ...profileContent,
     ...profile,
+    // special handle type to include required types
+    type: _addTypes({
+      existingTypes,
+      newTypes: profileContent.type
+    }),
+    // special handle zcaps to avoid overwrites
+    zcaps: {
+      ...profile.zcaps,
+      ...profileContent.zcaps
+    }
   };
 }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -120,6 +120,7 @@ export const createProfile = async ({
     profileContent && _updateProfileUser(
       {accessManager, profileId, profileContent})
   ]);
+
   // if profile content was provided, kick off request to update cache
   if(profileContent) {
     // set `useCache: false` to fetch a fresh copy

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -196,11 +196,12 @@ async function _updateProfileUser({
     id: profileId,
     async mutator({existing}) {
       const updatedDoc = {...existing};
-
+      const mergedContent = _mergeProfileContent({
+        profile: updatedDoc.content, profileContent
+      });
       // add profile agent content
       updatedDoc.content = {
-        ...updatedDoc.content,
-        ...profileContent,
+        ...mergedContent,
         // special handle type to include required types
         type: _addTypes({
           existingTypes: ['User', 'Profile'],

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -111,20 +111,30 @@ export const createProfile = async ({
   const {id: profileId} = await profileManager.createProfile(profileOptions);
 
   // update profile and profile agent user with content
-  const {accessManager, profile, profileAgent} = await profileManager
-    .getAccessManager({profileId});
+  const {
+    accessManager, profile, profileAgent
+  } = await profileManager.getAccessManager({profileId});
   const [user] = await Promise.all([
     profileAgentContent && _updateProfileAgentUser(
       {accessManager, profileAgent, profileAgentContent}),
     profileContent && _updateProfileUser(
       {accessManager, profileId, profileContent})
   ]);
-
   // if profile content was provided, kick off request to update cache
   if(profileContent) {
     // set `useCache: false` to fetch a fresh copy
     profileManager.getProfile({id: profileId, useCache: false})
       .catch(() => {});
+    const {name, color, shared} = profileContent;
+    if(name) {
+      profile.name = name;
+    }
+    if(color) {
+      profile.color = color;
+    }
+    if(shared) {
+      profile.shared = shared;
+    }
   }
 
   const t1 = Date.now();

--- a/lib/state.js
+++ b/lib/state.js
@@ -54,7 +54,7 @@ export async function initialize() {
  * @param {object} options.referenceIdPrefix - The prefix for the reference ID
  *   to pass to `profileManager.getProfileEdvAccess`.
  *
- * @returns {Promise<{edvClient}>}.
+ * @returns {Promise<{edvClient}>} - A Promise.
  */
 export async function getProfileEdvClient({
   profileId, referenceIdPrefix
@@ -74,7 +74,7 @@ export async function getProfileEdvClient({
  * @param {string} options.password - The password for unlocking the local
  *   credential store for the profile.
  *
- * @returns {Promise<{credentialStore}>}.
+ * @returns {Promise<{credentialStore}>} - A Promise.
  */
 export async function getCredentialStore({profileId, password} = {}) {
   // FIXME: may want option to leave out local version; if so, change the key


### PR DESCRIPTION
Not sure if this is the correct fix but I noticed that the profile here in `bedrock-vue-wallet` https://github.com/digitalbazaar/bedrock-vue-wallet/blob/main/components/Profiles.vue#L205-L209 which gets added to `tableData` is the `profile` returned from `createProfile()` here https://github.com/digitalbazaar/bedrock-web-wallet/blob/1f06f47f0a52afd43e15cf171b19e1ce6b280719/lib/helpers.js#L134 and fetched here https://github.com/digitalbazaar/bedrock-web-wallet/blob/main/lib/helpers.js#L114. That `profile` does not contain `name`, `color` and `shared` properties and so when we create new profiles in the wallet, the `name` and `color` doesn't get rendered until I refresh the page. This PR fixes that issue. 