### PR TITLE
Update `webLoader()` to attempt parsing json from the response body if there is no data on the response.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # bedrock-web-wallet ChangeLog
 
+## 11.1.0 - 2023-03-TBD
+
+### Changed
+- Update `webLoader()` to attempt parsing json from the response body if
+  there isn't data on the response.
+
 ## 11.0.1 - 2023-02-09
 
 ### Fixed

--- a/lib/documentLoader.js
+++ b/lib/documentLoader.js
@@ -76,10 +76,18 @@ async function webLoader(url) {
   } catch(e) {
     throw new Error('NotFoundError');
   }
-
+  let {data} = result;
+  // We reach this point if the request is successful. If there isn't data on
+  // the response, potentially the content-type header is not set. Therefore,
+  // attempt to parse the json from the response body.
+  // eslint-disable-next-line max-len
+  // See: https://github.com/digitalbazaar/http-client/blob/v3.3.0/lib/httpClient.js#L107-L114
+  if(!result.data) {
+    data = await result.json();
+  }
   return {
     contextUrl: null,
-    document: result.data,
+    document: data,
     documentUrl: url
   };
 }


### PR DESCRIPTION
Currently the context for the safechef credential is hosted on github pages `https://testing-json-ld.pages.dev/safechef-v1.context.jsonld`  and since we can't set custom headers there, the result here from `httpClient.get(url)` comes without data and we get the following error in the UI console. This update fixes that. This has been tested with `update-bedrock-web-wallet` branch on v wallet and `main` branch in chapi playground.

```
Error:  jsonld.InvalidUrl: Dereferencing a URL did not result in a JSON object. The response was valid JSON, but it was not a JSON object.
    at ContextResolver._fetchContext (webpack://veres-wallet/./node_modules/jsonld/lib/ContextResolver.js?:186:13)
    at async ContextResolver._resolveRemoteContext (webpack://veres-wallet/./node_modules/jsonld/lib/ContextResolver.js?:117:34)
    at async ContextResolver.resolve (webpack://veres-wallet/./node_modules/jsonld/lib/ContextResolver.js?:50:22)
    at async api.process (webpack://veres-wallet/./node_modules/jsonld/lib/context.js?:87:20)
    at async api.expand (webpack://veres-wallet/./node_modules/jsonld/lib/expand.js?:214:17)
    at async api.expand (webpack://veres-wallet/./node_modules/jsonld/lib/expand.js?:125:15)
    at async _expandObject (webpack://veres-wallet/./node_modules/jsonld/lib/expand.js?:905:25)
    at async api.expand (webpack://veres-wallet/./node_modules/jsonld/lib/expand.js?:251:3)
    at async jsonld.expand (webpack://veres-wallet/./node_modules/jsonld/lib/jsonld.js?:321:18)
    at async jsonld.toRDF (webpack://veres-wallet/./node_modules/jsonld/lib/jsonld.js?:680:16)
```