### PR TITLE
Add a cryptoSuites.supported alias.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [20.x]
     steps:
     - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
@@ -29,7 +29,7 @@ jobs:
           - 27017:27017
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [20.x]
     steps:
     - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
@@ -55,7 +55,7 @@ jobs:
           - 27017:27017
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [20.x]
     steps:
     - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # bedrock-web-wallet ChangeLog
 
+## 11.2.2 - 2023-06-xx
+
+### Fixed
+- Add a `cryptoSuites.supported` alias for `cryptosuites.supportedSuites`. The
+  exported value was renamed in the minor 11.2.0 release without backwards API
+  compatibility support.
+
 ## 11.2.1 - 2023-05-05
 
 ### Fixed

--- a/lib/cryptoSuites.js
+++ b/lib/cryptoSuites.js
@@ -13,6 +13,7 @@ export const supportedSuites = new Map([
   ['Ed25519Signature2020', ({signer}) => new Ed25519Signature2020({signer})],
   ['eddsa-2022', _createEddsa2022Suite]
 ]);
+export const supported = supportedSuites;
 
 function _createEddsa2022Suite({signer}) {
   // remove milliseconds precision


### PR DESCRIPTION
The renamed exported var should have triggered a major release.  Adding back a compatibility alias for v11.  `supported` is used in at least `bedrock-vue-wallet/lib/ChapiSharePage.vue`.