### PR TITLE
Ignore local embedding model cache directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ coverage
 node_modules
 reports
 .cache
+.fastembed_cache


### PR DESCRIPTION
## Summary

Adds `.fastembed_cache` to `.gitignore`. This directory holds a large,
locally downloaded embedding model (a multi-hundred-MB ONNX blob) created by
local tooling. It should never be committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
